### PR TITLE
build with --release by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ like `~/.cargo/bin`.
 ## Examples
 
 ```
-# defaults to profiling cargo run, which will
-# also profile the cargo compilation process
-# unless you've previously issued `cargo build`
+# defaults to profiling cargo run
 cargo flamegraph
 
-# if you'd like to profile your release build:
-cargo flamegraph --release
+# by default, `--release` profile is used, 
+# but you can override this:
+cargo flamegraph --dev
 
 # if you'd like to profile a specific binary:
 cargo flamegraph --bin=stress2


### PR DESCRIPTION
Also check if debug = true is enabled in Cargo.toml by parsing output

closes https://github.com/ferrous-systems/cargo-flamegraph/issues/15

This takes the simplest possible approach of fishing for `debuginfo` in 

```
   Compiling crt v0.1.0 (/home/matklad/projects/crt)
    Finished release [optimized + debuginfo] target(s) in 8.94s
```

The *proper* way to handle this would be to run the build with `--message-format=json` and parsing it, which is not too complicated, but still seems unnecessary.